### PR TITLE
feat: add createRoute path typings

### DIFF
--- a/docs/core/create-route.md
+++ b/docs/core/create-route.md
@@ -14,14 +14,28 @@ route.open();
 
 ### In-route path params
 
-You can specify params in route path and argon-router outputs type in route object generic by `typed-url-params` library. [Learn more about syntax](https://github.com/movpushmov/argon-router/tree/main/packages/argon-router-paths)
+Argon-router uses its own tool for parsing and building paths, while validating parameters for compliance with the specified type and other passed parameters constraints at runtime.
 
+By default, each parameter is treated as a string:
 ```ts
 import { createRoute } from '@argon-router/core';
 
 const postRoute = createRoute({ path: '/post/:id' });
 //       ^- Route<{ id: string }>
 ```
+
+However, you can also explicitly specify that a parameter should be of type `number` or `union`:
+```ts
+import { createRoute } from '@argon-router/core';
+
+const postRoute = createRoute({ path: '/post/:id<number>' });
+//       ^- Route<{ id: number }>
+
+const buildPostRoute = createRoute({ path: '/build-post/:mode<create|update>' });
+//       ^- Route<{ mode: 'create' | 'update' }>
+```
+
+You can also specify a number of modifiers for each parameter. More details about the syntax can be found [here](https://github.com/movpushmov/argon-router/tree/main/packages/argon-router-paths#supported-types).
 
 ### Parent paths
 

--- a/packages/argon-router-core/lib/create-route.ts
+++ b/packages/argon-router-core/lib/create-route.ts
@@ -13,14 +13,20 @@ import {
   RouteOpenedPayload,
 } from './types';
 
-import { ParseUrlParams } from '@argon-router/paths';
+import { ParseUrlParams, ValidatePath } from '@argon-router/paths';
 
-interface Config<T> {
-  path: T;
-  parent?: Route<any>;
-  beforeOpen?: Effect<void, any, any>[];
-}
-
+export type CreateRouteConfig<Path> =
+  ValidatePath<Path> extends ['invalid', infer Template]
+    ? {
+        path: Template;
+        parent?: Route<any>;
+        beforeOpen?: Effect<void, any, any>[];
+      }
+    : {
+        path: Path;
+        parent?: Route<any>;
+        beforeOpen?: Effect<void, any, any>[];
+      };
 /**
  * @description Creates argon route
  * @param config Route config
@@ -47,7 +53,7 @@ interface Config<T> {
  * ```
  */
 export function createRoute<T extends string, Params = ParseUrlParams<T>>(
-  config: Config<T>,
+  config: CreateRouteConfig<T>,
 ): Route<Params> {
   let asyncImport: AsyncBundleImport;
 

--- a/packages/argon-router-paths/lib/compile.ts
+++ b/packages/argon-router-paths/lib/compile.ts
@@ -30,7 +30,7 @@ import { prepareBuilder } from './prepare-builder';
 export function compile<T extends string, Params = ParseUrlParams<T>>(path: T) {
   const tokens: Token[] = [];
 
-  const regexp = /:(\w+)(<[\w|]+>)?({\d+\,\d+})?([+*?])?/;
+  const regexp = /:(\w+)(<[\s?\w|]+>)?({\d+\,\d+})?([+*?])?/;
   const parsedTokens = path.split('/').filter(Boolean);
 
   for (let i = 0; i < parsedTokens.length; i++) {
@@ -70,7 +70,7 @@ export function compile<T extends string, Params = ParseUrlParams<T>>(path: T) {
     if (genericProps && genericProps.includes('|')) {
       token.payload.genericProps = {
         type: 'union',
-        items: genericProps.split('|'),
+        items: genericProps.replaceAll(/\s/g, '').split('|'),
       };
     }
 

--- a/packages/argon-router-paths/lib/compile.ts
+++ b/packages/argon-router-paths/lib/compile.ts
@@ -70,7 +70,7 @@ export function compile<T extends string, Params = ParseUrlParams<T>>(path: T) {
     if (genericProps && genericProps.includes('|')) {
       token.payload.genericProps = {
         type: 'union',
-        items: genericProps.replaceAll(/\s/g, '').split('|'),
+        items: genericProps.split('|'),
       };
     }
 

--- a/packages/argon-router-paths/lib/get-token-parameters.ts
+++ b/packages/argon-router-paths/lib/get-token-parameters.ts
@@ -14,7 +14,10 @@ export function getTokenParameters(params: RegExpMatchArray | null) {
     }
 
     if (parameter.includes('<')) {
-      genericProps = parameter.replace('<', '').replace('>', '');
+      genericProps = parameter
+        .replaceAll(/\s/g, '')
+        .replace('<', '')
+        .replace('>', '');
       continue;
     }
 

--- a/packages/argon-router-paths/lib/index.ts
+++ b/packages/argon-router-paths/lib/index.ts
@@ -1,2 +1,3 @@
 export { compile } from './compile';
 export type { ParseUrlParams, Builder, Parser } from './types';
+export type { ValidatePath } from './validate-path';

--- a/packages/argon-router-paths/lib/types.ts
+++ b/packages/argon-router-paths/lib/types.ts
@@ -1,3 +1,13 @@
+export type ReplaceAll<
+  S,
+  From extends string,
+  To extends string,
+> = From extends ''
+  ? S
+  : S extends `${infer R1}${From}${infer R2}`
+    ? `${R1}${To}${ReplaceAll<R2, From, To>}`
+    : S;
+
 type Parameter<Name extends string, Payload> = {
   [k in Name]: Payload;
 };
@@ -43,11 +53,14 @@ type Union<
     ? T
     : Result | T;
 
-type GenericType<T extends string> = T extends `number`
-  ? number
-  : T extends `${infer A}|${infer B}`
-    ? Union<T>
-    : T;
+type GenericType<T extends string> =
+  ReplaceAll<T, ' ', ''> extends infer Trimmed
+    ? Trimmed extends `number`
+      ? number
+      : Trimmed extends `${infer A}|${infer B}`
+        ? Union<Trimmed>
+        : Trimmed
+    : never;
 
 export type UrlParameter<T extends string> =
   T extends `:${infer Name}<${infer Type}>${infer Modificator}`
@@ -168,6 +181,8 @@ type Case26 = ParseUrlParams<'/:id<hello|world>{1,2}*'>;
 type Case27 = ParseUrlParams<'/:id<number>{1,2}+'>;
 type Case28 = ParseUrlParams<'/:id<string>{1,2}+'>;
 type Case29 = ParseUrlParams<'/:id<hello|world>{1,2}+'>;
+type Case30 = ParseUrlParams<'/:id<number >'>;
+type Case31 = ParseUrlParams<'/:id<hello| world >'>;
 
 type Tests = [
   Assert<IsEqual<Case1, { id: string }>>,
@@ -199,4 +214,6 @@ type Tests = [
   Assert<IsEqual<Case27, { id: number[] }>>,
   Assert<IsEqual<Case28, { id: 'string'[] }>>,
   Assert<IsEqual<Case29, { id: TestsUnion[] }>>,
+  Assert<IsEqual<Case30, { id: number }>>,
+  Assert<IsEqual<Case31, { id: TestsUnion }>>,
 ];

--- a/packages/argon-router-paths/lib/validate-path.ts
+++ b/packages/argon-router-paths/lib/validate-path.ts
@@ -1,3 +1,5 @@
+import { ReplaceAll } from './types';
+
 type SplitPath<S> = string extends S
   ? string[]
   : S extends `${infer Head}/${infer Tail}`
@@ -19,12 +21,6 @@ type Join<T extends any[]> = T['length'] extends 0
         : `${F & string}/${Tail & string}`
       : never
     : never;
-
-type ReplaceAll<S, From extends string, To extends string> = From extends ''
-  ? S
-  : S extends `${infer R1}${From}${infer R2}`
-    ? `${R1}${To}${ReplaceAll<R2, From, To>}`
-    : S;
 
 type ValidateRange<Range> = Range extends `${infer L},${infer R}`
   ? L extends `${number}`

--- a/packages/argon-router-paths/lib/validate-path.ts
+++ b/packages/argon-router-paths/lib/validate-path.ts
@@ -1,0 +1,168 @@
+type SplitPath<S> = string extends S
+  ? string[]
+  : S extends `${infer Head}/${infer Tail}`
+    ? Head extends ''
+      ? SplitPath<Tail>
+      : Tail extends ''
+        ? [Head]
+        : [Head, ...SplitPath<Tail>]
+    : [S];
+
+type JoinPath<T extends any[]> = `/${Join<T>}`;
+
+type Join<T extends any[]> = T['length'] extends 0
+  ? never
+  : T extends [infer F, ...infer Rest]
+    ? Join<Rest> extends infer Tail
+      ? [Tail] extends [never]
+        ? `${F & string}`
+        : `${F & string}/${Tail & string}`
+      : never
+    : never;
+
+type ReplaceAll<S, From extends string, To extends string> = From extends ''
+  ? S
+  : S extends `${infer R1}${From}${infer R2}`
+    ? `${R1}${To}${ReplaceAll<R2, From, To>}`
+    : S;
+
+type ValidateRange<Range> = Range extends `${infer L},${infer R}`
+  ? L extends `${number}`
+    ? R extends `${number}`
+      ? ['valid', `{${Range}`]
+      : ['invalid', `{${L},number}`]
+    : R extends `${number}`
+      ? ['invalid', `{number,${R}}`]
+      : ['invalid', `{number,number}`]
+  : ['invalid', `{number,number}`];
+
+type ValidateTypes<GenTypes> = GenTypes extends 'number'
+  ? 'valid'
+  : GenTypes extends ''
+    ? ['invalid', `<number,union>`]
+    : GenTypes extends string | `${string}|${string}`
+      ? 'valid'
+      : ['invalid', `<number,union>`];
+
+type ValidateTokenBase<
+  Token extends string,
+  PostFix extends string = '',
+> = Token extends `${infer Param}<${infer Types}>{${infer Range}}` // has Types, Range
+  ? ValidateTypes<Types> extends ['invalid', infer TypesReplacer]
+    ? ['invalid', `:${Param}${TypesReplacer & string}{${Range}}${PostFix}`]
+    : ValidateRange<Range> extends ['invalid', infer RangeReplacer]
+      ? ['invalid', `:${Param}<${Types}>${RangeReplacer & string}${PostFix}`]
+      : 'valid'
+  : Token extends `${infer Param}<${infer Types}>` // has only Types
+    ? ValidateTypes<Types> extends ['invalid', infer TypesReplacer]
+      ? ['invalid', `:${Param}${TypesReplacer & string}${PostFix}`]
+      : 'valid'
+    : Token extends `${infer Param}{${infer Range}}` // has only Range
+      ? ValidateRange<Range> extends ['invalid', infer RangeReplacer]
+        ? ['invalid', `:${Param}${RangeReplacer & string}${PostFix}`]
+        : 'valid'
+      : 'valid'; // base param
+
+type ValidateToken<Token> = Token extends `:${infer RawParam}`
+  ? RawParam extends `${infer WithoutModifier}${'*' | '?' | '+'}`
+    ? RawParam extends `${WithoutModifier}${infer Modifier}`
+      ? ValidateTokenBase<WithoutModifier, Modifier>
+      : never
+    : ValidateTokenBase<RawParam>
+  : 'valid';
+
+type ValidateTokens<
+  Path,
+  Current,
+  Res extends string[] = [],
+> = Current extends [infer Token, ...infer Rest]
+  ? ValidateToken<ReplaceAll<Token, ' ', ''>> extends [
+      'invalid',
+      infer TokenReplacer,
+    ]
+    ? ['invalid', JoinPath<[...Res, TokenReplacer, ...Rest]>]
+    : ValidateTokens<Path, Rest, [...Res, Token & string]>
+  : Path;
+
+export type ValidatePath<Path> = ValidateTokens<Path, SplitPath<Path>>;
+
+type IsEqual<T, Payload> = T extends Payload ? true : false;
+type Assert<T extends true> = T;
+
+type Case1 = '/:id';
+type Case2 = '/:id?';
+type Case3 = '/:id*';
+type Case4 = '/:id+';
+type Case5 = '/:id<string>';
+type Case6 = '/:id<number>';
+type Case7 = '/:id<hello|world>';
+type Case8 = '/:id<string>?';
+type Case9 = '/:id<number>?';
+type Case10 = '/:id<hello|world>?';
+type Case11 = '/:id<string>*';
+type Case12 = '/:id<number>*';
+type Case13 = '/:id<hello|world>*';
+type Case14 = '/:id<string>+';
+type Case15 = '/:id<number>+';
+type Case16 = '/:id<hello|world>+';
+type Case17 = '/:id{1,2}';
+type Case18 = '/:id<number>{1,2}';
+type Case19 = '/:id<string>{1,2}';
+type Case20 = '/:id<hello|world>{1,2}';
+type Case21 = '/:id<number>{1,2}?';
+type Case22 = '/:id<string>{1,2}?';
+type Case23 = '/:id<hello|world>{1,2}?';
+type Case24 = '/:id<number>{1,2}*';
+type Case25 = '/:id<string>{1,2}*';
+type Case26 = '/:id<hello|world>{1,2}*';
+type Case27 = '/:id<number>{1,2}+';
+type Case28 = '/:id<string>{1,2}+';
+type Case29 = '/:id<hello|world>{1,2}+';
+
+type Case30 = '/:id<hello|world>{err,err}+';
+type Case31 = '/:id<hello|world>{1,err}';
+type Case32 = '/:id<hello|world>{err,1}+';
+
+type Tests = [
+  Assert<IsEqual<ValidatePath<Case1>, Case1>>,
+  Assert<IsEqual<ValidatePath<Case2>, Case2>>,
+  Assert<IsEqual<ValidatePath<Case3>, Case3>>,
+  Assert<IsEqual<ValidatePath<Case4>, Case4>>,
+  Assert<IsEqual<ValidatePath<Case5>, Case5>>,
+  Assert<IsEqual<ValidatePath<Case6>, Case6>>,
+  Assert<IsEqual<ValidatePath<Case7>, Case7>>,
+  Assert<IsEqual<ValidatePath<Case8>, Case8>>,
+  Assert<IsEqual<ValidatePath<Case9>, Case9>>,
+  Assert<IsEqual<ValidatePath<Case10>, Case10>>,
+  Assert<IsEqual<ValidatePath<Case11>, Case11>>,
+  Assert<IsEqual<ValidatePath<Case12>, Case12>>,
+  Assert<IsEqual<ValidatePath<Case13>, Case13>>,
+  Assert<IsEqual<ValidatePath<Case14>, Case14>>,
+  Assert<IsEqual<ValidatePath<Case15>, Case15>>,
+  Assert<IsEqual<ValidatePath<Case16>, Case16>>,
+  Assert<IsEqual<ValidatePath<Case17>, Case17>>,
+  Assert<IsEqual<ValidatePath<Case18>, Case18>>,
+  Assert<IsEqual<ValidatePath<Case19>, Case19>>,
+  Assert<IsEqual<ValidatePath<Case20>, Case20>>,
+  Assert<IsEqual<ValidatePath<Case21>, Case21>>,
+  Assert<IsEqual<ValidatePath<Case22>, Case22>>,
+  Assert<IsEqual<ValidatePath<Case23>, Case23>>,
+  Assert<IsEqual<ValidatePath<Case24>, Case24>>,
+  Assert<IsEqual<ValidatePath<Case25>, Case25>>,
+  Assert<IsEqual<ValidatePath<Case26>, Case26>>,
+  Assert<IsEqual<ValidatePath<Case27>, Case27>>,
+  Assert<IsEqual<ValidatePath<Case28>, Case28>>,
+  Assert<IsEqual<ValidatePath<Case29>, Case29>>,
+  Assert<
+    IsEqual<
+      ValidatePath<Case30>,
+      ['invalid', '/:id<hello|world>{number,number}+']
+    >
+  >,
+  Assert<
+    IsEqual<ValidatePath<Case31>, ['invalid', '/:id<hello|world>{1,number}']>
+  >,
+  Assert<
+    IsEqual<ValidatePath<Case32>, ['invalid', '/:id<hello|world>{number,1}+']>
+  >,
+];

--- a/packages/argon-router-paths/tests/index.test.ts
+++ b/packages/argon-router-paths/tests/index.test.ts
@@ -35,8 +35,33 @@ describe('parse path', () => {
     });
   });
 
+  test('parse path with generic parameter with dummy spaces (number)', () => {
+    const { parse } = compile('/profile/:id< number >');
+
+    expect(parse('/profile/12323')).toStrictEqual({
+      path: '/profile/12323',
+      params: { id: 12323 },
+    });
+  });
+
   test('parse path with generic parameter (union)', () => {
     const { parse } = compile('/profile/:id<hello|world>');
+
+    expect(parse('/profile/hello')).toStrictEqual({
+      path: '/profile/hello',
+      params: { id: 'hello' },
+    });
+
+    expect(parse('/profile/world')).toStrictEqual({
+      path: '/profile/world',
+      params: { id: 'world' },
+    });
+
+    expect(parse('/profile/test')).toStrictEqual(null);
+  });
+
+  test('parse path with generic parameter with dummy spaces (union)', () => {
+    const { parse } = compile('/profile/:id<hello | world >');
 
     expect(parse('/profile/hello')).toStrictEqual({
       path: '/profile/hello',


### PR DESCRIPTION
PR добавляет проверку на уровне типов на соответствие пути роута шаблону

Сейчас все пробелы в токенах обрезаются, например:
`/:id<foo|bar>` и `/:id< foo | bar>` являются равноценными записями - не уверен по этому поводу, можно обсудить как правильнее

![image](https://github.com/user-attachments/assets/efdb4b77-5e49-4cc8-8c31-88f83236b6c9)
![image](https://github.com/user-attachments/assets/69cbae59-4dc4-47c9-aedf-c6d008683d95)
