### PR TITLE
fix: missing $params in chained routes

### DIFF
--- a/packages/argon-router-core/lib/chain-route.ts
+++ b/packages/argon-router-core/lib/chain-route.ts
@@ -107,7 +107,7 @@ export function chainRoute<T>(
     sample({
       clock: openOn as Unit<any>[],
       source: virtualRoute.$params,
-      fn: (params) => params as unknown as RouteOpenedPayload<T>,
+      fn: (params) => ({ params }) as unknown as RouteOpenedPayload<T>,
       target: virtualRoute.open,
     });
   }

--- a/packages/argon-router-core/tests/chained-routes.test.ts
+++ b/packages/argon-router-core/tests/chained-routes.test.ts
@@ -60,5 +60,6 @@ describe('chained routes', () => {
     });
 
     expect(scope.getState(virtual.$isOpened)).toBeTruthy();
+    expect(scope.getState(virtual.$params)).toStrictEqual({ id: '1' });
   });
 });


### PR DESCRIPTION
## Description:
While working with the library, I discovered a bug where `$params` were not being preserved when using chained routes.
The problem was reproduced in according test.



